### PR TITLE
Fix TTS playback and document server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-"# rpg-master" 
+# RPG Master Backend
+
+This repository contains a simple Express server and static front-end used for
+an AI powered game master. The `/chat` endpoint proxies requests to the OpenAI
+Assistants API while `/tts` generates speech using ElevenLabs.
+
+### Running locally
+
+```bash
+npm install
+npm start
+```
+
+### Front-end notes
+
+`public/main.js` expects the `/tts` endpoint to respond with JSON containing an
+`url` field pointing to the generated `.mp3` file. The script will download that
+audio and play it in the browser.

--- a/public/main.js
+++ b/public/main.js
@@ -15,12 +15,15 @@ document.addEventListener("DOMContentLoaded", function () {
     })
     .then(res => {
       if (!res.ok) throw new Error("Błąd TTS");
-      return res.blob();
+      return res.json();
     })
-    .then(blob => {
-      const url = URL.createObjectURL(blob);
-      const audio = new Audio(url);
-      audio.play();
+    .then(data => {
+      if (!data.url) throw new Error("Brak URL z TTS");
+      const audio = new Audio(data.url);
+      audio.crossOrigin = "anonymous";
+      audio.play().catch(err => {
+        console.error("Błąd odtwarzania:", err);
+      });
     })
     .catch(err => {
       console.error("Błąd odtwarzania głosu:", err);


### PR DESCRIPTION
## Summary
- repair `public/main.js` so it uses the `/tts` JSON response to play audio
- expand `README` with instructions and details on TTS behaviour

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_684c3d60646483258884e05d9e43570c