### PR TITLE
Add optional Wix endpoint integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-"# rpg-master" 
+# rpg-master
+
+This project provides a simple voice-controlled RPG game master using Express and OpenAI's assistants API. The server returns both text responses and generated speech audio using ElevenLabs.
+
+## Environment Variables
+
+- `OPENAI_API_KEY` – API key for OpenAI.
+- `ELEVEN_API_KEY` – API key for ElevenLabs text‑to‑speech.
+- `ASSISTANT_ID` – ID of your OpenAI assistant.
+- `WIX_ENDPOINT` – *(optional)* URL of a Wix HTTP function that should receive the generated text and audio URL. If provided, each response will be POSTed to this endpoint as JSON `{ text, audio }`.
+
+Run the server with:
+
+```bash
+npm start
+```
+
+The client files are served from the `public` directory.

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const PORT = process.env.PORT || 3000;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const ELEVEN_API_KEY = process.env.ELEVEN_API_KEY;
 const ASSISTANT_ID = process.env.ASSISTANT_ID;
+const WIX_ENDPOINT = process.env.WIX_ENDPOINT; // optional Wix endpoint for sending replies
 
 app.use(cors());
 app.use(express.json());
@@ -111,6 +112,18 @@ app.post('/chat', async (req, res) => {
     const filepath = path.join(__dirname, 'public', filename);
     fs.writeFileSync(filepath, buffer);
     const audioUrl = `https://rpg-master.onrender.com/${filename}`;
+
+    if (WIX_ENDPOINT) {
+      try {
+        await fetch(WIX_ENDPOINT, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text: reply, audio: audioUrl })
+        });
+      } catch (err) {
+        console.warn('⚠️ Failed to send data to Wix:', err);
+      }
+    }
 
     res.json({ reply, audio: audioUrl });
   } catch (e) {


### PR DESCRIPTION
## Summary
- document environment variables in README
- allow server to forward replies to a Wix endpoint

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_684c8e442f2083259888d6f1ba32c985